### PR TITLE
Add ip_to_signed_int function

### DIFF
--- a/lib/puppet/parser/functions/ip_to_int.rb
+++ b/lib/puppet/parser/functions/ip_to_int.rb
@@ -1,7 +1,7 @@
 module Puppet::Parser::Functions
 
   newfunction(:ip_to_int, :type => :rvalue, :doc => <<-'ENDHEREDOC'
-    Converts a dotted address of the form 192.168.0.1 into its 32 bit integer representation
+    Converts a dotted address of the form 192.168.0.1 into its unsigned 32 bit integer representation
 
     ENDHEREDOC
     ) do |args|

--- a/lib/puppet/parser/functions/ip_to_signed_int.rb
+++ b/lib/puppet/parser/functions/ip_to_signed_int.rb
@@ -1,7 +1,7 @@
 module Puppet::Parser::Functions
 
   newfunction(:ip_to_signed_int, :type => :rvalue, :doc => <<-'ENDHEREDOC'
-    Converts a dotted address of the form 192.168.0.1 into its 32 bit integer representation
+    Converts a dotted address of the form 192.168.0.1 into its signed 32 bit integer representation
 
     ENDHEREDOC
     ) do |args|

--- a/lib/puppet/parser/functions/ip_to_signed_int.rb
+++ b/lib/puppet/parser/functions/ip_to_signed_int.rb
@@ -1,0 +1,27 @@
+module Puppet::Parser::Functions
+
+  newfunction(:ip_to_signed_int, :type => :rvalue, :doc => <<-'ENDHEREDOC'
+    Converts a dotted address of the form 192.168.0.1 into its 32 bit integer representation
+
+    ENDHEREDOC
+    ) do |args|
+
+    unless args.length == 1 then
+      raise Puppet::ParseError, ("ip_to_signed_int(): wrong number of arguments (#{args.length}; must be 1)")
+    end
+    arg = args[0]
+    unless arg.respond_to?('to_s') then
+      raise Puppet::ParseError, ("#{arg.inspect} is not a string. It looks to be a #{arg.class}")
+    end
+
+    arg = arg.to_s
+    begin
+      int_val = IPAddr.new(arg).to_i
+      [int_val].pack('L').unpack('l')[0] # Pack as unsigned int, unpack as signed int
+    rescue ArgumentError => e
+      raise Puppet::ParseError, (e)
+    end
+  end
+
+end
+

--- a/spec/functions/ip_to_signed_int_spec.rb
+++ b/spec/functions/ip_to_signed_int_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'ip_to_signed_int' do
+  lo_ip = '10.1.2.3'
+  hi_ip = '192.168.1.12'
+
+  it { should run.with_params(lo_ip).and_return(167838211) }
+
+  it { should run.with_params(hi_ip).and_return(-1062731508) }
+
+  it 'should work' do
+    expect { subject.call([lo_ip]) }.not_to raise_error()
+  end
+
+  it 'should work' do
+    expect { subject.call([hi_ip]) }.not_to raise_error()
+  end
+
+  it 'should fail with no args' do
+    expect { subject.call([]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with :undef' do
+    expect { subject.call([:undef]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with many args' do
+    expect { subject.call(['foo', 'bar']) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail if given insane data type' do
+    expect { subject.call([ [] ]) }.to raise_error(Puppet::ParseError)
+  end
+end
+


### PR DESCRIPTION
Some applications require a signed integer representation of an IP address, and there doesn't seem to be a convenient way in Puppet (without creating another function) to convert an unsigned 32-bit value to a signed one.