### PR TITLE
Moving ips_in_netblocks into this module, and providing test coverage

### DIFF
--- a/lib/puppet/parser/functions/ips_in_netblocks.rb
+++ b/lib/puppet/parser/functions/ips_in_netblocks.rb
@@ -1,0 +1,37 @@
+require 'ipaddr'
+
+module Puppet::Parser::Functions
+  #Returns true if, for each IP in the first argument, a netblock containing it
+  #is within those specified in the second netblock.
+  newfunction(:ips_in_netblocks, :type => :rvalue) do |args|
+
+    if args.size != 2
+       raise Puppet::ParseError, ("Wrong number of arguments: expecting 2")
+    end
+
+    check_ips = args[0]
+    netblocks = args[1]
+    valid_ips = []
+
+    if !check_ips.kind_of?(Array) or !netblocks.kind_of?(Array)
+      raise Puppet::ParseError, ("Wrong type of arguments: expecting arrays")
+    end
+
+    if check_ips.empty? or netblocks.empty?
+      raise Puppet::ParseError, ("Invalid arguments: zero-length arrays are illegal")
+    end
+
+    check_ips.each do |ipaddress|
+      netblocks.each do |netblock|
+        if IPAddr.new(netblock).include? IPAddr.new(ipaddress)
+          valid_ips.push(ipaddress)
+        end
+      end
+    end
+    if check_ips.size == valid_ips.size
+      true
+    else
+      false
+    end
+  end
+end

--- a/spec/functions/ips_in_netblocks_spec.rb
+++ b/spec/functions/ips_in_netblocks_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'ips_in_netblocks' do
+  netblocks = ['192.168.0.0/24']
+  ips = ['192.168.0.1']
+
+  it { should run.with_params(ips, netblocks).and_return(true) }
+
+  it 'should work' do
+    expect { subject.call([ips, netblocks]) }.not_to raise_error()
+  end
+
+  it 'should fail with no args' do
+    expect { subject.call([]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with :undef' do
+    expect { subject.call([:undef, netblocks]) }.to raise_error(Puppet::ParseError)
+    expect { subject.call([ips, :undef]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with many args' do
+    expect { subject.call(['foo', 'bar', 'quux']) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail if given insane data type' do
+    expect { subject.call([ {}, netblocks ]) }.to raise_error(Puppet::ParseError)
+  end
+end
+


### PR DESCRIPTION
This is a new function which checks all IPs in the first argument, ensuring they are covered by netblocks in the second argument. If this is the case, it returns true; otherwise it returns false.
