### PR TITLE
add parse_http_uri function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 script: bundle exec rake test

--- a/lib/puppet/parser/functions/parse_http_uri.rb
+++ b/lib/puppet/parser/functions/parse_http_uri.rb
@@ -1,0 +1,21 @@
+require 'uri'
+
+module Puppet::Parser::Functions
+  newfunction(:parse_http_uri, :type => :rvalue) do |args|
+    raise(Puppet::ParseError,
+          'parse_http_uri: wrong number of args') if args.size != 1
+
+    begin
+      uri = URI(args.first)
+      raise "Only supports http or https" unless uri.scheme.downcase =~ /^http/
+    rescue => e
+      raise Puppet::ParseError, "bad arg in parse_http_uri - '#{args.inspect}': #{e}"
+    end
+
+    {
+      'scheme' => uri.scheme.downcase,
+      'host'   => uri.host.downcase,
+      'path'   => uri.path.empty? ? '/' : uri.path,
+    }
+  end
+end

--- a/spec/functions/parse_http_uri_spec.rb
+++ b/spec/functions/parse_http_uri_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe 'parse_http_uri' do
+
+  it 'should fail with no args' do
+    expect { subject.call([]) }.to \
+      raise_error Puppet::ParseError, /number of args/
+  end
+
+  it 'should fail with many args' do
+    expect { subject.call([:undef, :undef1]) }.to \
+      raise_error Puppet::ParseError, /number of args/
+  end
+
+  it 'should fail with non-http uri' do
+    expect { subject.call(['smtp://foo.bar']) }.to \
+      raise_error Puppet::ParseError, /http or https/
+  end
+
+  it 'should fail with undef' do
+    expect { subject.call([:undef]) }.to \
+      raise_error Puppet::ParseError, /bad argument/
+  end
+
+  it 'should fail with insane data type' do
+    expect { subject.call([ [] ]) }.to \
+      raise_error Puppet::ParseError, /bad argument/
+  end
+
+  it 'should work for http uri' do
+    should run.with_params('HTTP://example.com').and_return({
+      'scheme' => 'http',
+      'host'   => 'example.com',
+      'path'   => '/',
+    })
+  end
+
+  it 'should work for http with trailing / and no path' do
+    should run.with_params('http://example.com/').and_return({
+      'scheme' => 'http',
+      'host'   => 'example.com',
+      'path'   => '/',
+    })
+  end
+
+  it 'should work for https uri' do
+    should run.with_params('https://example.COM/foo/BAR').and_return({
+      'scheme' => 'https',
+      'host'   => 'example.com',
+      'path'   => '/foo/BAR',
+    })
+  end
+
+end


### PR DESCRIPTION
Simple function that converts HTTP URI from string to a hash with 'scheme', 'host' and 'path' keys.