### PR TITLE
allow specifying an array as second parameter of ip_in_cidr() function

### DIFF
--- a/lib/puppet/parser/functions/ip_in_cidr.rb
+++ b/lib/puppet/parser/functions/ip_in_cidr.rb
@@ -14,17 +14,28 @@ module Puppet::Parser::Functions
       raise Puppet::ParseError, ("#{ip.inspect} is not a string. It looks to be a #{ip.class}")
     end
     ip = ip.to_s
-    cidr = args[1]
-    unless cidr.respond_to?('to_s') then
-      raise Puppet::ParseError, ("#{cidr.inspect} is not a string. It looks to be a #{cidr.class}")
+    if args[1].is_a? String
+      cidr_ary = [ args[1] ]
+    elsif args[1].is_a? Array
+      cidr_ary = args[1]
+    else
+      raise Puppet::ParseError, ("#{args[1].inspect} is not a string. It looks to be a #{args[1].class}")
     end
-    cidr = cidr.to_s
-    begin
-      IPAddr.new(cidr).include? IPAddr.new(ip)
-    rescue ArgumentError => e
-      raise Puppet::ParseError, (e)
-    end
+    matching = true
+    cidr_ary.each { |cidr|
+      cidr = cidr.to_s
+      unless cidr.respond_to?('to_s') then
+        raise Puppet::ParseError, ("#{cidr.inspect} is not a string. It looks to be a #{cidr.class}")
+      end
+      begin
+        if not IPAddr.new(cidr).include? IPAddr.new(ip)
+          matching = false
+        end
+      rescue ArgumentError => e
+         raise Puppet::ParseError, (e)
+      end
+    }
+    return matching
   end
-
 end
 

--- a/lib/puppet/parser/functions/ip_in_cidr.rb
+++ b/lib/puppet/parser/functions/ip_in_cidr.rb
@@ -21,21 +21,20 @@ module Puppet::Parser::Functions
     else
       raise Puppet::ParseError, ("#{args[1].inspect} is not a string. It looks to be a #{args[1].class}")
     end
-    matching = true
     cidr_ary.each { |cidr|
       cidr = cidr.to_s
       unless cidr.respond_to?('to_s') then
         raise Puppet::ParseError, ("#{cidr.inspect} is not a string. It looks to be a #{cidr.class}")
       end
       begin
-        if not IPAddr.new(cidr).include? IPAddr.new(ip)
-          matching = false
+        if IPAddr.new(cidr).include? IPAddr.new(ip)
+          return true
         end
       rescue ArgumentError => e
          raise Puppet::ParseError, (e)
       end
     }
-    return matching
+    return false
   end
 end
 


### PR DESCRIPTION
Hello,

Had the idea of allowing specifying an array as second parameter of ip_in_cidr() to test if an IP address  matches any of the networks listed in an array. I have that requirement in my Puppet recipes. 

My first ruby attempts - so not sure if my code changes are ideal for this.
But it seems to work for my purpose.

Best Regards,
Andreas