### PR TITLE
Add cidr_to_range function to generate a range of IP addresses

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,13 +1,13 @@
-##Overview
+## Overview
 [![Build Status](https://travis-ci.org/Yelp/puppet-netstdlib.png)](https://travis-ci.org/Yelp/puppet-netstdlib)
 
 `netstdlib` is a collection of puppet functions and facts for network related work.
 
 These functions and facts are very handy when using puppet to do complex logic
-on code that deals with configuring or interpreting network interfaces. 
+on code that deals with configuring or interpreting network interfaces.
 
-Most of them simply expose the native ruby implementations into the puppet 
-manifest so you can use them to say, edit OpenStack config files, or 
+Most of them simply expose the native ruby implementations into the puppet
+manifest so you can use them to say, edit OpenStack config files, or
 manipulate DCHP server pools.
 
 ## Examples
@@ -35,7 +35,7 @@ $my_name = gethostbyaddr2array($::ipaddress)
 notify { "My reverse dns seems to be: ${my_name}": }
 ```
 
-##Functions
+## Functions
 
 cidr_to_broadcast
 -------------------
@@ -49,9 +49,14 @@ cidr_to_network
 -------------------
 Converts an CIDR address of the form 192.168.0.1/24 into its network address
 
+cidr_to_range
+-------------------
+Converts an CIDR address of the form 192.168.0.1/24 into a range of IP addresses, excluding the network and
+broadcast addresses.
+
 fqdn_mac
 -------------------
-Generate MAC addresses based on the results of fqdn_rand. Useful for VMs that 
+Generate MAC addresses based on the results of fqdn_rand. Useful for VMs that
 might have the same hostname.
 
 gethostbyaddr2array
@@ -83,8 +88,7 @@ netmask_to_masklen
 -------------------
 Converts a netmask of the form 255.255.0.0 to the mask length (e.g. 16)
 
-##Limitations
+## Limitations
 
-Puppet functions are server-side, facts are client side. Keep this in mind as 
+Puppet functions are server-side, facts are client side. Keep this in mind as
 any DNS related functions will take place on the server.
-

--- a/lib/puppet/parser/functions/cidr_to_range.rb
+++ b/lib/puppet/parser/functions/cidr_to_range.rb
@@ -12,7 +12,7 @@ module Puppet::Parser::Functions
     end
 
     arg = args[0]
-    unless arg.respond_to?('to_s')
+    unless arg.kind_of? String
       raise Puppet::ParseError, ("#{arg.inspect} is not a string. It looks to be a #{arg.class}")
     end
 

--- a/lib/puppet/parser/functions/cidr_to_range.rb
+++ b/lib/puppet/parser/functions/cidr_to_range.rb
@@ -7,22 +7,22 @@ module Puppet::Parser::Functions
     ENDHEREDOC
     ) do |args|
 
-    unless args.length == 1 then
+    unless args.length == 1
       raise Puppet::ParseError, ("cidr_to_range(): wrong number of arguments (#{args.length}; must be 1)")
     end
+
     arg = args[0]
-    unless arg.respond_to?('to_s') then
+    unless arg.respond_to?('to_s')
       raise Puppet::ParseError, ("#{arg.inspect} is not a string. It looks to be a #{arg.class}")
     end
 
-    cidr = nil
     begin
       cidr = IPAddr.new(arg.to_s)
     rescue ArgumentError => e
       raise Puppet::ParseError, (e)
     end
 
-    ips = cidr.to_range.each.map { |ip| ip.to_s }
+    ips = cidr.to_range.map { |ip| ip.to_s }
     ips.shift
     ips.pop
     ips

--- a/lib/puppet/parser/functions/cidr_to_range.rb
+++ b/lib/puppet/parser/functions/cidr_to_range.rb
@@ -1,0 +1,30 @@
+module Puppet::Parser::Functions
+
+  newfunction(:cidr_to_range, :type => :rvalue, :doc => <<-'ENDHEREDOC'
+    Converts an CIDR address of the form 192.168.0.1/24 into a range of IP address excluding the network and broadcast
+    addresses.
+
+    ENDHEREDOC
+    ) do |args|
+
+    unless args.length == 1 then
+      raise Puppet::ParseError, ("cidr_to_range(): wrong number of arguments (#{args.length}; must be 1)")
+    end
+    arg = args[0]
+    unless arg.respond_to?('to_s') then
+      raise Puppet::ParseError, ("#{arg.inspect} is not a string. It looks to be a #{arg.class}")
+    end
+
+    cidr = nil
+    begin
+      cidr = IPAddr.new(arg.to_s)
+    rescue ArgumentError => e
+      raise Puppet::ParseError, (e)
+    end
+
+    ips = cidr.to_range.each.map { |ip| ip.to_s }
+    ips.shift
+    ips.pop
+    ips
+  end
+end

--- a/spec/functions/cidr_to_range_spec.rb
+++ b/spec/functions/cidr_to_range_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'cidr_to_range' do
-  cidr = '192.168.1.0/29'
+  let (:cidr) { '192.168.1.0/29' }
 
   it 'should return the range ips excluding the network and broadcast addresses' do
     ips = [
@@ -30,5 +30,13 @@ describe 'cidr_to_range' do
   end
   it 'should fail if given insane data type' do
     expect { subject.call([ [] ]) }.to raise_error(Puppet::ParseError)
+  end
+
+  context "with a /32 cidr" do
+    let (:cidr) { '192.168.1.0/32' }
+
+    it 'should return an empty list' do
+      should run.with_params(cidr).and_return([])
+    end
   end
 end

--- a/spec/functions/cidr_to_range_spec.rb
+++ b/spec/functions/cidr_to_range_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'cidr_to_range' do
+  cidr = '192.168.1.0/29'
+
+  it 'should return the range ips excluding the network and broadcast addresses' do
+    ips = [
+      '192.168.1.1',
+      '192.168.1.2',
+      '192.168.1.3',
+      '192.168.1.4',
+      '192.168.1.5',
+      '192.168.1.6',
+    ]
+    should run.with_params(cidr).and_return(ips)
+  end
+
+  it 'should work' do
+    expect { subject.call([cidr]) }.not_to raise_error()
+  end
+
+  it 'should fail with no args' do
+    expect { subject.call([]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with :undef' do
+    expect { subject.call([:undef]) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail with many args' do
+    expect { subject.call(['foo', 'bar']) }.to raise_error(Puppet::ParseError)
+  end
+  it 'should fail if given insane data type' do
+    expect { subject.call([ [] ]) }.to raise_error(Puppet::ParseError)
+  end
+end


### PR DESCRIPTION
This excludes the network and broadcast addresses.

```puppet
ips = cidr_to_range('192.168.1.0/29')

# returns this array
[
  '192.168.1.1',
  '192.168.1.2',
  '192.168.1.3',
  '192.168.1.4',
  '192.168.1.5',
  '192.168.1.6',
]
```